### PR TITLE
esp_driver: spi_slave_api: fix SPI2 pin muxing

### DIFF
--- a/esp/esp_driver/network_adapter/main/spi_slave_api.c
+++ b/esp/esp_driver/network_adapter/main/spi_slave_api.c
@@ -37,18 +37,21 @@ static const char TAG[] = "SPI_DRIVER";
 				((VAL)& SPI_DMA_ALIGNMENT_MASK))
 
 #if (CONFIG_ESP_SPI_CONTROLLER == 3)
+    /* VSPI in ref manual, SPI3_HOST in spi_types.h */
     #define ESP_SPI_CONTROLLER 2
     #define GPIO_MOSI 23
     #define GPIO_MISO 19
     #define GPIO_SCLK 18
     #define GPIO_CS    5
 #elif (CONFIG_ESP_SPI_CONTROLLER == 2)
+    /* HSPI in ref manual, SPI2_HOST in spi_types.h */
     #define ESP_SPI_CONTROLLER 1
-    #define GPIO_MOSI 12
-    #define GPIO_MISO 13
-    #define GPIO_SCLK 15
-    #define GPIO_CS   14
+    #define GPIO_MOSI 13
+    #define GPIO_MISO 12
+    #define GPIO_SCLK 14
+    #define GPIO_CS   15
 #else
+    /* only SPI2 & SPI3 can be configured as slave */
     #error "Please choose correct ESP SPI"
 #endif
 


### PR DESCRIPTION
Also add some comments about those signals to help understanding the
values and why only 2 intances are available.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>