### PR TITLE
Fix for incorrect array size used

### DIFF
--- a/host/host_common/commands.c
+++ b/host/host_common/commands.c
@@ -512,8 +512,8 @@ int wifi_get_ap_config (esp_hosted_control_config_t *ap_config)
         }
         if (resp->resp_get_ap_config->bssid.data) {
             strncpy((char *)ap_config->station.bssid,
-                    (char *)resp->resp_get_ap_config->bssid.data, MAC_LENGTH);
-            ap_config->station.bssid[MAC_LENGTH-1] = '\0';
+                    (char *)resp->resp_get_ap_config->bssid.data, BSSID_LENGTH);
+            ap_config->station.bssid[BSSID_LENGTH-1] = '\0';
         }
 
         ap_config->station.channel = resp->resp_get_ap_config->chnl;


### PR DESCRIPTION
Spotted this when compiling my own project with the c api's using -Wall and -pedantic