### PR TITLE
Prevent NOHZ tick-stop error in Linux driver

### DIFF
--- a/host/linux/host_driver/esp32/main.c
+++ b/host/linux/host_driver/esp32/main.c
@@ -382,7 +382,7 @@ static void process_rx_packet(struct sk_buff *skb)
 		skb->ip_summed = CHECKSUM_NONE;
 
 		/* Forward skb to kernel */
-		netif_rx(skb);
+		netif_rx_ni(skb);
 
 		priv->stats.rx_bytes += skb->len;
 		priv->stats.rx_packets++;


### PR DESCRIPTION
Currently, netif_rx is called in non-interrupt context.
This leads to error `NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #08!!!` in latest 5.14 kernel.
This patch fixes this problem by converting netif_rx to netif_rx_ni.

Refer to https://www.mail-archive.com/ath10k@lists.infradead.org/msg13772.html