### PR TITLE
esp-serial: support automatic creation of esp serial device

### DIFF
--- a/docs/Linux_based_host/SDIO_setup.md
+++ b/docs/Linux_based_host/SDIO_setup.md
@@ -35,7 +35,7 @@ Please reboot Raspberry-Pi after changing this file.
 $ cd host/linux/host_control/
 $ ./rpi_init.sh sdio
 ```
-* This script compiles and loads host driver on Raspberry-Pi. It also creates virtual serial interface `/dev/esps0` which is used as a control interface for Wi-Fi on ESP peripheral
+* This script compiles and loads host driver on Raspberry-Pi. The driver creates virtual serial interface `/dev/esps0` which is used as a control interface for Wi-Fi on ESP peripheral.
 
 ### 2.2 ESP Peripheral Firmware
 One can load pre-built release binaries on ESP peripheral or compile those from source. Below subsection explains both these methods.

--- a/docs/Linux_based_host/SPI_setup.md
+++ b/docs/Linux_based_host/SPI_setup.md
@@ -69,7 +69,7 @@ Please reboot Raspberry-Pi after changing this file.
 $ cd host/linux/host_control/
 $ ./rpi_init.sh spi
 ```
-* This script compiles and loads host driver on Raspberry-Pi. It also creates virtual serial interface `/dev/esps0` which is used as a control interface for Wi-Fi on ESP peripheral
+* This script compiles and loads host driver on Raspberry-Pi. The driver creates virtual serial interface `/dev/esps0` which is used as a control interface for Wi-Fi on ESP peripheral
 
 ### 2.2 ESP Peripheral Firmware
 One can load pre-built release binaries on ESP peripheral or compile those from source. Below subsection explains both these methods.

--- a/host/linux/host_control/rpi_init.sh
+++ b/host/linux/host_control/rpi_init.sh
@@ -33,7 +33,6 @@ wlan_init()
 
     cd ../host_driver/esp32/
     if [ `lsmod | grep esp32 | wc -l` != "0" ]; then
-        sudo rm /dev/esps0
         if [ `lsmod | grep esp32_sdio | wc -l` != "0" ]; then
             sudo rmmod esp32_sdio &> /dev/null
             else
@@ -56,7 +55,6 @@ wlan_init()
 	fi
 	if [ `lsmod | grep esp32 | wc -l` != "0" ]; then
 		echo "esp32 module inserted "
-		sudo mknod /dev/esps0 c 221 0
 		sudo chmod 666 /dev/esps0
 		echo "/dev/esps0 device created"
 		echo "RPi init successfully completed"


### PR DESCRIPTION
This patch use `class_create` and `device_create` to automatically create `/dev/esps0` when driver is loaded, eliminating the need to `mknod /dev/esps0`.