### PR TITLE
fix(esp_spi): fix compile error when build without CONFIG_SUPPORT_ESP_SERIAL

### DIFF
--- a/host/linux/host_driver/esp32/spi/esp_spi.c
+++ b/host/linux/host_driver/esp32/spi/esp_spi.c
@@ -509,7 +509,9 @@ static void spi_exit(void)
 		spi_context.spi_workqueue = NULL;
 	}
 
+#ifdef CONFIG_SUPPORT_ESP_SERIAL
 	esp_serial_cleanup();
+#endif
 	esp_remove_card(spi_context.adapter);
 
 	if (spi_context.adapter->hcidev)


### PR DESCRIPTION

wrap esp_spi.c:esp_serial_cleanup() up with CONFIG_SUPPORT_ESP_SERIAL