### PR TITLE
Rework read to remove malloc buf_handle

### DIFF
--- a/esp/esp_driver/network_adapter/main/app_main.c
+++ b/esp/esp_driver/network_adapter/main/app_main.c
@@ -377,12 +377,11 @@ void process_serial_rx_pkt(uint8_t *buf)
 	}
 }
 
-void process_rx_pkt(interface_buffer_handle_t **buf_handle_p)
+void process_rx_pkt(interface_buffer_handle_t *buf_handle)
 {
 	struct esp_payload_header *header = NULL;
 	uint8_t *payload = NULL;
 	uint16_t payload_len = 0;
-	interface_buffer_handle_t *buf_handle = *buf_handle_p;
 
 	header = (struct esp_payload_header *) buf_handle->payload;
 	payload = buf_handle->payload + le16toh(header->offset);
@@ -421,7 +420,7 @@ void process_rx_pkt(interface_buffer_handle_t **buf_handle_p)
 /* Get data from host */
 void recv_task(void* pvParameters)
 {
-	interface_buffer_handle_t *buf_handle = NULL;
+	interface_buffer_handle_t buf_handle;
 
 	for (;;) {
 
@@ -433,18 +432,14 @@ void recv_task(void* pvParameters)
 
 		// receive data from transport layer
 		if (if_context && if_context->if_ops && if_context->if_ops->read) {
-			buf_handle = if_context->if_ops->read(if_handle);
-			if (!buf_handle) {
+			int len = if_context->if_ops->read(if_handle, &buf_handle);
+			if (len <= 0) {
 				usleep(10*1000);
 				continue;
 			}
 		}
 
 		process_rx_pkt(&buf_handle);
-
-
-		free(buf_handle);
-		buf_handle = NULL;
 	}
 }
 

--- a/esp/esp_driver/network_adapter/main/interface.h
+++ b/esp/esp_driver/network_adapter/main/interface.h
@@ -79,7 +79,7 @@ typedef struct {
 typedef struct {
 	interface_handle_t * (*init)(void);
 	int32_t (*write)(interface_handle_t *handle, interface_buffer_handle_t *buf_handle);
-	interface_buffer_handle_t * (*read)(interface_handle_t *handle);
+	int (*read)(interface_handle_t *handle, interface_buffer_handle_t *buf_handle);
 	esp_err_t (*reset)(interface_handle_t *handle);
 	void (*deinit)(interface_handle_t *handle);
 } if_ops_t;

--- a/esp/esp_driver/network_adapter/main/spi_slave_api.c
+++ b/esp/esp_driver/network_adapter/main/spi_slave_api.c
@@ -112,7 +112,7 @@ static QueueHandle_t spi_tx_queue[MAX_PRIORITY_QUEUES] = {NULL};
 static interface_handle_t * esp_spi_init(void);
 static int32_t esp_spi_write(interface_handle_t *handle,
 				interface_buffer_handle_t *buf_handle);
-static interface_buffer_handle_t * esp_spi_read(interface_handle_t *if_handle);
+static int esp_spi_read(interface_handle_t *if_handle, interface_buffer_handle_t * buf_handle);
 static esp_err_t esp_spi_reset(interface_handle_t *handle);
 static void esp_spi_deinit(interface_handle_t *handle);
 static void esp_spi_read_done(void *handle);
@@ -603,18 +603,14 @@ static void IRAM_ATTR esp_spi_read_done(void *handle)
 	}
 }
 
-static interface_buffer_handle_t * esp_spi_read(interface_handle_t *if_handle)
+static int esp_spi_read(interface_handle_t *if_handle, interface_buffer_handle_t *buf_handle)
 {
-	interface_buffer_handle_t *buf_handle = NULL;
 	esp_err_t ret = ESP_OK;
 
 	if (!if_handle) {
 		ESP_LOGE(TAG, "Invalid arguments to esp_spi_read\n");
-		return NULL;
+		return 0;
 	}
-
-	buf_handle = malloc(sizeof(interface_buffer_handle_t));
-	assert(buf_handle);
 
 	while (1) {
 		if(uxQueueMessagesWaiting(spi_rx_queue[PRIO_Q_SERIAL])) {
@@ -632,11 +628,9 @@ static interface_buffer_handle_t * esp_spi_read(interface_handle_t *if_handle)
 	}
 
 	if (ret != pdTRUE) {
-		free(buf_handle);
-		buf_handle = NULL;
-		return NULL;
+		return 0;
 	}
-	return buf_handle;
+	return 1; // buf_handle->; // TODO a real length
 }
 
 static esp_err_t esp_spi_reset(interface_handle_t *handle)


### PR DESCRIPTION
malloc/free should be avoided in high traffic code to improve performance and reduce heap fragmentation. This change removes one pair.
