### PR TITLE
Remove need to copy protocomm_priv.h

### DIFF
--- a/docs/Linux_based_host/Linux_based_readme.md
+++ b/docs/Linux_based_host/Linux_based_readme.md
@@ -209,10 +209,7 @@ ESP-IDF release version to be used for ESP peripherals are
 | ESP32-C3 | release v4.3 |
 | ESP32-C3 (HCI over UART)| release v4.4 (beta)|
 
-Clone appropriate ESP-IDF version as per your ESP peripheral. The control path between Linux host and ESP peripheral is based on `protobuf`. For that, corresponding stack layer, `protocomm` from ESP-IDF is used. Run following command in ESP-IDF directory to make `protocomm_priv.h` available for control path.
-```
-$ git mv components/protocomm/src/common/protocomm_priv.h components/protocomm/include/common/
-```
+Clone appropriate ESP-IDF version as per your ESP peripheral. The control path between Linux host and ESP peripheral is based on `protobuf`. For that, corresponding stack layer, `protocomm` from ESP-IDF is used.
 
 ### 2.3 ESP-Hosted Code Repository
 Clone esp-hosted repository on Linux host.

--- a/docs/MCU_based_host/MCU_based_readme.md
+++ b/docs/MCU_based_host/MCU_based_readme.md
@@ -121,10 +121,7 @@ For windows user, you can also program the binaries using ESP Flash Programming 
 
 #### 2.2.2 Compilation using source
 Please use above mentioned ESP-IDF repository release branch for your ESP peripheral.
-The control path between host and ESP peripheral is based on `protobuf`. For that `protocomm` layer from ESP-IDF is used. Run following command to make `protocomm_priv.h` available for control path.
-```
-$ git mv components/protocomm/src/common/protocomm_priv.h components/protocomm/include/common/
-```
+The control path between host and ESP peripheral is based on `protobuf`. For that `protocomm` layer from ESP-IDF is used. 
 
 Navigate to `esp/esp_driver/network_adapter` directory
 ##### Using make

--- a/esp/esp_driver/network_adapter/main/CMakeLists.txt
+++ b/esp/esp_driver/network_adapter/main/CMakeLists.txt
@@ -11,3 +11,7 @@ endif()
 register_component()
 set(PROJECT_VERSION "-DPROJECT_VERSION=0.3")
 target_compile_definitions(${COMPONENT_LIB} PRIVATE ${PROJECT_VERSION})
+
+# Add directory of protocomm_priv.h to include paths
+idf_component_get_property(protocomm_dir protocomm COMPONENT_DIR)
+target_include_directories(${COMPONENT_LIB} PRIVATE "${protocomm_dir}/src/common")


### PR DESCRIPTION
Queries the build system for the directory of the `protocomm` component. Uses this information to add the directory containing `protocomm_priv.h` to `main`'s private include paths.