### PR TITLE
ESP build error with SPI Interface config

### DIFF
--- a/esp/esp_driver/network_adapter/main/spi_slave_api.c
+++ b/esp/esp_driver/network_adapter/main/spi_slave_api.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include "soc/gpio_reg.h"
 #include "esp_log.h"
 #include "interface.h"
 #include "adapter.h"


### PR DESCRIPTION
Hi author.
I built this project with some option changes( use spi interface instead of sdio as default) I met some build error

# environment 
docker from https://hub.docker.com/r/espressif/idf

# configuration changes : 
```
root@e281c0ba68d6:/esp-hosted/esp/esp_driver/network_adapter# git diff
diff --git a/esp/esp_driver/network_adapter/sdkconfig.defaults.esp32 b/esp/esp_driver/network_adapter/sdkconfig.defaults.esp32
index aed5aab..a73ccc4 100644
--- a/esp/esp_driver/network_adapter/sdkconfig.defaults.esp32
+++ b/esp/esp_driver/network_adapter/sdkconfig.defaults.esp32
@@ -34,3 +34,17 @@ CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM=64
 #OTA
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 CONFIG_PARTITION_TABLE_TWO_OTA=y
+#
+# Example Configuration
+#
+# CONFIG_ESP_SDIO_HOST_INTERFACE is not set
+CONFIG_ESP_SPI_HOST_INTERFACE=y
+
+#
+# SPI Configuration
+#
+CONFIG_ESP_SPI_CONTROLLER=3
+CONFIG_ESP_SPI_GPIO_HANDSHAKE=21
+CONFIG_ESP_SPI_GPIO_DATA_READY=22
+# end of SPI Configuration
+
```
# error log
```
root@e281c0ba68d6:/esp-hosted/esp/esp_driver/network_adapter# idf.py build           
Executing action: all (aliases: build)
Running ninja in directory /esp-hosted/esp/esp_driver/network_adapter/build
Executing "ninja all"...
[39/927] Generating ../../partition_table/partition-table.bin
Partition table binary generated. Contents:
*******************************************************************************
# ESP-IDF Partition Table
# Name, Type, SubType, Offset, Size, Flags
nvs,data,nvs,0x9000,16K,
otadata,data,ota,0xd000,8K,
phy_init,data,phy,0xf000,4K,
factory,app,factory,0x10000,1M,
ota_0,app,ota_0,0x110000,1M,
ota_1,app,ota_1,0x210000,1M,
*******************************************************************************
[790/927] Performing configure step for 'bootloader'
-- Found Git: /usr/bin/git (found version "2.25.1")
-- The C compiler identification is GNU 8.4.0
-- The CXX compiler identification is GNU 8.4.0
-- The ASM compiler identification is GNU
-- Found assembler: /opt/esp/tools/xtensa-esp32-elf/esp-2021r2-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/esp/tools/xtensa-esp32-elf/esp-2021r2-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/esp/tools/xtensa-esp32-elf/esp-2021r2-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building ESP-IDF components for target esp32
-- Project sdkconfig file /esp-hosted/esp/esp_driver/network_adapter/sdkconfig
-- Adding linker script /opt/esp/idf/components/soc/esp32/ld/esp32.peripherals.ld
-- Adding linker script /opt/esp/idf/components/esp_rom/esp32/ld/esp32.rom.ld
-- Adding linker script /opt/esp/idf/components/esp_rom/esp32/ld/esp32.rom.api.ld
-- Adding linker script /opt/esp/idf/components/esp_rom/esp32/ld/esp32.rom.libgcc.ld
-- Adding linker script /opt/esp/idf/components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld
-- Adding linker script /opt/esp/idf/components/bootloader/subproject/main/ld/esp32/bootloader.ld
-- Adding linker script /opt/esp/idf/components/bootloader/subproject/main/ld/esp32/bootloader.rom.ld
-- Components: bootloader bootloader_support efuse esp32 esp_common esp_hw_support esp_rom esp_system esptool_py freertos hal log main micro-ecc newlib partition_table soc spi_flash xtensa
-- Component paths: /opt/esp/idf/components/bootloader /opt/esp/idf/components/bootloader_support /opt/esp/idf/components/efuse /opt/esp/idf/components/esp32 /opt/esp/idf/components/esp_common /opt/esp/idf/components/esp_hw_support /opt/esp/idf/components/esp_rom /opt/esp/idf/components/esp_system /opt/esp/idf/components/esptool_py /opt/esp/idf/components/freertos /opt/esp/idf/components/hal /opt/esp/idf/components/log /opt/esp/idf/components/bootloader/subproject/main /opt/esp/idf/components/bootloader/subproject/components/micro-ecc /opt/esp/idf/components/newlib /opt/esp/idf/components/partition_table /opt/esp/idf/components/soc /opt/esp/idf/components/spi_flash /opt/esp/idf/components/xtensa
-- Configuring done
-- Generating done
-- Build files have been written to: /esp-hosted/esp/esp_driver/network_adapter/build/bootloader
[916/927] Building C object esp-idf/main/CMakeFiles/__idf_main.dir/app_main.c.obj
In file included from ../main/app_main.c:47:
/opt/esp/idf/components/driver/deprecated/driver/periph_ctrl.h:7:2: warning: #warning driver/periph_ctrl.h header is no longer used, and will be removed in future versions. [-Wcpp]
 #warning driver/periph_ctrl.h header is no longer used, and will be removed in future versions.
  ^~~~~~~
../main/app_main.c: In function 'app_main':
../main/app_main.c:772:2: warning: 'tcpip_adapter_init' is deprecated [-Wdeprecated-declarations]
  tcpip_adapter_init();
  ^~~~~~~~~~~~~~~~~~
In file included from /opt/esp/idf/components/esp_netif/include/esp_netif.h:27,
                 from /opt/esp/idf/components/esp_event/include/esp_event_legacy.h:14,
                 from /opt/esp/idf/components/esp_event/include/esp_event.h:20,
                 from /opt/esp/idf/components/esp_wifi/include/esp_private/wifi.h:29,
                 from ../main/app_main.c:29:
/opt/esp/idf/components/tcpip_adapter/include/tcpip_adapter.h:34:6: note: declared here
 void tcpip_adapter_init(void)  __attribute__ ((deprecated));
      ^~~~~~~~~~~~~~~~~~
[918/927] Building C object esp-idf/main/CMakeFiles/__idf_main.dir/spi_slave_api.c.obj
FAILED: esp-idf/main/CMakeFiles/__idf_main.dir/spi_slave_api.c.obj
ccache /opt/esp/tools/xtensa-esp32-elf/esp-2021r2-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc -DHAVE_CONFIG_H -DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\" -DPROJECT_VERSION=0.4 -DUNITY_INCLUDE_CONFIG_H -DWITH_POSIX -Iconfig -I../main -I/esp-hosted/common/include -I/opt/esp/idf/components/protocomm/src/common -I/opt/esp/idf/components/newlib/platform_include -I/opt/esp/idf/components/freertos/FreeRTOS-Kernel/include -I/opt/esp/idf/components/freertos/esp_additions/include/freertos -I/opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/include -I/opt/esp/idf/components/freertos/esp_additions/include -I/opt/esp/idf/components/esp_hw_support/include -I/opt/esp/idf/components/esp_hw_support/include/soc -I/opt/esp/idf/components/esp_hw_support/include/soc/esp32 -I/opt/esp/idf/components/esp_hw_support/port/esp32/. -I/opt/esp/idf/components/heap/include -I/opt/esp/idf/components/log/include -I/opt/esp/idf/components/lwip/include/apps -I/opt/esp/idf/components/lwip/include/apps/sntp -I/opt/esp/idf/components/lwip/lwip/src/include -I/opt/esp/idf/components/lwip/port/esp32/include -I/opt/esp/idf/components/lwip/port/esp32/include/arch -I/opt/esp/idf/components/soc/include -I/opt/esp/idf/components/soc/esp32/. -I/opt/esp/idf/components/soc/esp32/include -I/opt/esp/idf/components/hal/esp32/include -I/opt/esp/idf/components/hal/include -I/opt/esp/idf/components/hal/platform_port/include -I/opt/esp/idf/components/esp_rom/include -I/opt/esp/idf/components/esp_rom/include/esp32 -I/opt/esp/idf/components/esp_rom/esp32 -I/opt/esp/idf/components/esp_common/include -I/opt/esp/idf/components/esp_system/include -I/opt/esp/idf/components/esp_system/port/soc -I/opt/esp/idf/components/esp_system/port/include/private -I/opt/esp/idf/components/xtensa/include -I/opt/esp/idf/components/xtensa/esp32/include -I/opt/esp/idf/components/driver/include -I/opt/esp/idf/components/driver/esp32/include -I/opt/esp/idf/components/driver/deprecated -I/opt/esp/idf/components/esp_pm/include -I/opt/esp/idf/components/esp_ringbuf/include -I/opt/esp/idf/components/efuse/include -I/opt/esp/idf/components/efuse/esp32/include -I/opt/esp/idf/components/vfs/include -I/opt/esp/idf/components/esp_wifi/include -I/opt/esp/idf/components/esp_event/include -I/opt/esp/idf/components/esp_netif/include -I/opt/esp/idf/components/esp_eth/include -I/opt/esp/idf/components/tcpip_adapter/include -I/opt/esp/idf/components/esp_phy/include -I/opt/esp/idf/components/esp_phy/esp32/include -I/opt/esp/idf/components/esp_timer/include -I/opt/esp/idf/components/mbedtls/port/include -I/opt/esp/idf/components/mbedtls/mbedtls/include -I/opt/esp/idf/components/mbedtls/esp_crt_bundle/include -I/opt/esp/idf/components/app_update/include -I/opt/esp/idf/components/spi_flash/include -I/opt/esp/idf/components/bootloader_support/include -I/opt/esp/idf/components/bootloader_support/bootloader_flash/include -I/opt/esp/idf/components/nvs_flash/include -I/opt/esp/idf/components/pthread/include -I/opt/esp/idf/components/wpa_supplicant/include -I/opt/esp/idf/components/wpa_supplicant/port/include -I/opt/esp/idf/components/wpa_supplicant/esp_supplicant/include -I/opt/esp/idf/components/app_trace/include -I/opt/esp/idf/components/asio/asio/asio/include -I/opt/esp/idf/components/asio/port/include -I/opt/esp/idf/components/bt/common/osi/include -I/opt/esp/idf/components/bt/include/esp32/include -I/opt/esp/idf/components/bt/common/api/include/api -I/opt/esp/idf/components/bt/common/btc/profile/esp/blufi/include -I/opt/esp/idf/components/bt/common/btc/profile/esp/include -I/opt/esp/idf/components/unity/include -I/opt/esp/idf/components/unity/unity/src -I/opt/esp/idf/components/cmock/CMock/src -I/opt/esp/idf/components/coap/port/include -I/opt/esp/idf/components/coap/libcoap/include -I/opt/esp/idf/components/console -I/opt/esp/idf/components/nghttp/port/include -I/opt/esp/idf/components/nghttp/nghttp2/lib/includes -I/opt/esp/idf/components/esp-tls -I/opt/esp/idf/components/esp-tls/esp-tls-crypto -I/opt/esp/idf/components/esp_adc_cal/include -I/opt/esp/idf/components/esp_gdbstub/include -I/opt/esp/idf/components/esp_gdbstub/xtensa -I/opt/esp/idf/components/esp_gdbstub/esp32 -I/opt/esp/idf/components/esp_hid/include -I/opt/esp/idf/components/tcp_transport/include -I/opt/esp/idf/components/esp_http_client/include -I/opt/esp/idf/components/esp_http_server/include -I/opt/esp/idf/components/esp_https_ota/include -I/opt/esp/idf/components/esp_lcd/include -I/opt/esp/idf/components/esp_lcd/interface -I/opt/esp/idf/components/protobuf-c/protobuf-c -I/opt/esp/idf/components/protocomm/include/common -I/opt/esp/idf/components/protocomm/include/security -I/opt/esp/idf/components/protocomm/include/transports -I/opt/esp/idf/components/mdns/include -I/opt/esp/idf/components/esp_local_ctrl/include -I/opt/esp/idf/components/sdmmc/include -I/opt/esp/idf/components/esp_serial_slave_link/include -I/opt/esp/idf/components/esp_websocket_client/include -I/opt/esp/idf/components/espcoredump/include -I/opt/esp/idf/components/espcoredump/include/port/xtensa -I/opt/esp/idf/components/expat/expat/expat/lib -I/opt/esp/idf/components/expat/port/include -I/opt/esp/idf/components/wear_levelling/include -I/opt/esp/idf/components/fatfs/diskio -I/opt/esp/idf/components/fatfs/vfs -I/opt/esp/idf/components/fatfs/src -I/opt/esp/idf/components/freemodbus/common/include -I/opt/esp/idf/components/idf_test/include -I/opt/esp/idf/components/idf_test/include/esp32 -I/opt/esp/idf/components/ieee802154/include -I/opt/esp/idf/components/json/cJSON -I/opt/esp/idf/components/mqtt/esp-mqtt/include -I/opt/esp/idf/components/openssl/include -I/opt/esp/idf/components/perfmon/include -I/opt/esp/idf/components/spiffs/include -I/opt/esp/idf/components/ulp/include -I/opt/esp/idf/components/wifi_provisioning/include -mlongcalls -Wno-frame-address  -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -ggdb -Og -fmacro-prefix-map=/esp-hosted/esp/esp_driver/network_adapter=. -fmacro-prefix-map=/opt/esp/idf=/IDF -fstrict-volatile-bitfields -Wno-error=unused-but-set-variable -fno-jump-tables -fno-tree-switch-conversion -std=gnu99 -Wno-old-style-declaration -D_GNU_SOURCE -DIDF_VER=\"v5.0-dev-1080-g7d43be9675\" -DESP_PLATFORM -D_POSIX_READER_WRITER_LOCKS -MD -MT esp-idf/main/CMakeFiles/__idf_main.dir/spi_slave_api.c.obj -MF esp-idf/main/CMakeFiles/__idf_main.dir/spi_slave_api.c.obj.d -o esp-idf/main/CMakeFiles/__idf_main.dir/spi_slave_api.c.obj -c ../main/spi_slave_api.c
In file included from /opt/esp/idf/components/soc/esp32/include/soc/soc.h:11,
                 from /opt/esp/idf/components/soc/include/soc/soc_memory_types.h:12,
                 from /opt/esp/idf/components/esp_hw_support/include/soc/compare_set.h:12,
                 from /opt/esp/idf/components/esp_hw_support/include/soc/spinlock.h:12,
                 from /opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos/portmacro.h:42,
                 from /opt/esp/idf/components/freertos/FreeRTOS-Kernel/include/freertos/portable.h:51,
                 from /opt/esp/idf/components/freertos/FreeRTOS-Kernel/include/freertos/FreeRTOS.h:63,
                 from /opt/esp/idf/components/driver/include/driver/spi_slave.h:12,
                 from ../main/spi_slave_api.c:23:
../main/spi_slave_api.c: In function 'generate_startup_event':
../main/spi_slave_api.c:250:17: error: 'GPIO_OUT_W1TS_REG' undeclared (first use in this function)
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
                 ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:71: note: in definition of macro 'TRY_STATIC_ASSERT'
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                                                                       ^~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:57: note: in expansion of macro 'IS_DPORT_REG'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                                         ^~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:250:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
../main/spi_slave_api.c:250:17: note: each undeclared identifier is reported only once for each function it appears in
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
                 ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:71: note: in definition of macro 'TRY_STATIC_ASSERT'
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                                                                       ^~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:57: note: in expansion of macro 'IS_DPORT_REG'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                                         ^~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:250:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: first argument to '__builtin_choose_expr' not a constant
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:250:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: expression in static assertion is not an integer
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:250:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
../main/spi_slave_api.c: In function 'spi_post_setup_cb':
../main/spi_slave_api.c:260:17: error: 'GPIO_OUT_W1TS_REG' undeclared (first use in this function)
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_handshake));
                 ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:71: note: in definition of macro 'TRY_STATIC_ASSERT'
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                                                                       ^~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:57: note: in expansion of macro 'IS_DPORT_REG'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                                         ^~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:260:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: first argument to '__builtin_choose_expr' not a constant
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:260:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: expression in static assertion is not an integer
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:260:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
../main/spi_slave_api.c: In function 'spi_post_trans_cb':
../main/spi_slave_api.c:268:17: error: 'GPIO_OUT_W1TC_REG' undeclared (first use in this function)
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
                 ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:71: note: in definition of macro 'TRY_STATIC_ASSERT'
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                                                                       ^~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:57: note: in expansion of macro 'IS_DPORT_REG'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                                         ^~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:268:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: first argument to '__builtin_choose_expr' not a constant
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:268:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: expression in static assertion is not an integer
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:268:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
../main/spi_slave_api.c: In function 'get_next_tx_buffer':
../main/spi_slave_api.c:300:17: error: 'GPIO_OUT_W1TC_REG' undeclared (first use in this function)
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_data_ready));
                 ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:71: note: in definition of macro 'TRY_STATIC_ASSERT'
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                                                                       ^~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:57: note: in expansion of macro 'IS_DPORT_REG'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                                         ^~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:300:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: first argument to '__builtin_choose_expr' not a constant
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:300:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: expression in static assertion is not an integer
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:300:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
../main/spi_slave_api.c: In function 'esp_spi_init':
../main/spi_slave_api.c:513:17: error: 'GPIO_OUT_W1TC_REG' undeclared (first use in this function)
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
                 ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:71: note: in definition of macro 'TRY_STATIC_ASSERT'
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                                                                       ^~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:57: note: in expansion of macro 'IS_DPORT_REG'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                                         ^~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:513:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: first argument to '__builtin_choose_expr' not a constant
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:513:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: expression in static assertion is not an integer
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:513:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_handshake));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: first argument to '__builtin_choose_expr' not a constant
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:514:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: expression in static assertion is not an integer
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:514:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TC_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
../main/spi_slave_api.c: In function 'esp_spi_write':
../main/spi_slave_api.c:612:17: error: 'GPIO_OUT_W1TS_REG' undeclared (first use in this function)
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
                 ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:71: note: in definition of macro 'TRY_STATIC_ASSERT'
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                                                                       ^~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:57: note: in expansion of macro 'IS_DPORT_REG'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                                         ^~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:612:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: first argument to '__builtin_choose_expr' not a constant
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:612:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
/opt/esp/idf/components/esp_common/include/esp_assert.h:23:28: error: expression in static assertion is not an integer
             _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
                            ^~~~~~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:33:38: note: in expansion of macro 'TRY_STATIC_ASSERT'
 #define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
                                      ^~~~~~~~~~~~~~~~~
/opt/esp/idf/components/soc/esp32/include/soc/soc.h:112:13: note: in expansion of macro 'ASSERT_IF_DPORT_REG'
             ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
             ^~~~~~~~~~~~~~~~~~~
../main/spi_slave_api.c:612:2: note: in expansion of macro 'WRITE_PERI_REG'
  WRITE_PERI_REG(GPIO_OUT_W1TS_REG, (1 << gpio_data_ready));
  ^~~~~~~~~~~~~~
[919/927] Performing build step for 'bootloader'
[1/95] Generating project_elf_src_esp32.c
[2/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/i2c_periph.c.obj
[3/95] Building C object CMakeFiles/bootloader.elf.dir/project_elf_src_esp32.c.obj
[4/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/dac_periph.c.obj
[5/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/adc_periph.c.obj
[6/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/lldesc.c.obj
[7/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/gpio_periph.c.obj
[8/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/lcd_periph.c.obj
[9/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/ledc_periph.c.obj
[10/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/interrupts.c.obj
[11/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/i2s_periph.c.obj
[12/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/mcpwm_periph.c.obj
[13/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/pcnt_periph.c.obj
[14/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/rmt_periph.c.obj
[15/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/rtc_io_periph.c.obj
[16/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/sdmmc_periph.c.obj
[17/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/sigmadelta_periph.c.obj
[18/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/sdio_slave_periph.c.obj
[19/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/timer_periph.c.obj
[20/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/spi_periph.c.obj
[21/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/touch_sensor_periph.c.obj
[22/95] Building C object esp-idf/soc/CMakeFiles/__idf_soc.dir/esp32/uart_periph.c.obj
[23/95] Building C object esp-idf/hal/CMakeFiles/__idf_hal.dir/mpu_hal.c.obj
[24/95] Building C object esp-idf/hal/CMakeFiles/__idf_hal.dir/cpu_hal.c.obj
[25/95] Building C object esp-idf/hal/CMakeFiles/__idf_hal.dir/wdt_hal_iram.c.obj
[26/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_mem.c.obj
[27/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_common_loader.c.obj
[28/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_clock_init.c.obj
[29/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_common.c.obj
[30/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_random.c.obj
[31/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/bootloader_flash/src/bootloader_flash.c.obj
[32/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/flash_encrypt.c.obj
[33/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_random_esp32.c.obj
[34/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/secure_boot.c.obj
[35/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/flash_partitions.c.obj
[36/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_utility.c.obj
[37/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/bootloader_flash/src/flash_qio_mode.c.obj
[38/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_clock_loader.c.obj
[39/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/esp_image_format.c.obj
[40/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_efuse_esp32.c.obj
[41/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_console_loader.c.obj
[42/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/bootloader_flash/src/bootloader_flash_config_esp32.c.obj
[43/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_console.c.obj
[44/95] Building C object esp-idf/micro-ecc/CMakeFiles/__idf_micro-ecc.dir/uECC_verify_antifault.c.obj
[45/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/esp32/bootloader_soc.c.obj
[46/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_init.c.obj
[47/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/bootloader_panic.c.obj
[48/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/esp32/bootloader_sha.c.obj
[49/95] Building C object esp-idf/efuse/CMakeFiles/__idf_efuse.dir/esp32/esp_efuse_table.c.obj
[50/95] Building C object esp-idf/efuse/CMakeFiles/__idf_efuse.dir/esp32/esp_efuse_fields.c.obj
[51/95] Building C object esp-idf/efuse/CMakeFiles/__idf_efuse.dir/src/esp_efuse_fields.c.obj
[52/95] Building C object esp-idf/efuse/CMakeFiles/__idf_efuse.dir/src/esp_efuse_api.c.obj
[53/95] Building C object esp-idf/efuse/CMakeFiles/__idf_efuse.dir/esp32/esp_efuse_utility.c.obj
[54/95] Building C object esp-idf/bootloader_support/CMakeFiles/__idf_bootloader_support.dir/src/esp32/bootloader_esp32.c.obj
[55/95] Building C object esp-idf/esp_system/CMakeFiles/__idf_esp_system.dir/esp_err.c.obj
[56/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/compare_set.c.obj
[57/95] Building C object esp-idf/efuse/CMakeFiles/__idf_efuse.dir/src/esp_efuse_api_key_esp32.c.obj
[58/95] Building C object esp-idf/efuse/CMakeFiles/__idf_efuse.dir/src/esp_efuse_utility.c.obj
[59/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/cpu_util.c.obj
[60/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/rtc_clk_init.c.obj
[61/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/rtc_pm.c.obj
[62/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/rtc_init.c.obj
[63/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/rtc_sleep.c.obj
[64/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/rtc_time.c.obj
[65/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/chip_info.c.obj
[66/95] Building C object esp-idf/xtensa/CMakeFiles/__idf_xtensa.dir/eri.c.obj
[67/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/rtc_clk.c.obj
[68/95] Building C object esp-idf/esp_rom/CMakeFiles/__idf_esp_rom.dir/patches/esp_rom_crc.c.obj
[69/95] Building C object esp-idf/xtensa/CMakeFiles/__idf_xtensa.dir/xt_trax.c.obj
[70/95] Building C object esp-idf/esp_hw_support/CMakeFiles/__idf_esp_hw_support.dir/port/esp32/rtc_wdt.c.obj
[71/95] Building C object esp-idf/esp_rom/CMakeFiles/__idf_esp_rom.dir/patches/esp_rom_sys.c.obj
[72/95] Building ASM object esp-idf/esp_rom/CMakeFiles/__idf_esp_rom.dir/patches/esp_rom_longjmp.S.obj
[73/95] Building C object esp-idf/esp_common/CMakeFiles/__idf_esp_common.dir/src/esp_err_to_name.c.obj
[74/95] Building C object esp-idf/esp_rom/CMakeFiles/__idf_esp_rom.dir/patches/esp_rom_tjpgd.c.obj
[75/95] Building C object esp-idf/esp_rom/CMakeFiles/__idf_esp_rom.dir/patches/esp_rom_uart.c.obj
[76/95] Building C object esp-idf/main/CMakeFiles/__idf_main.dir/bootloader_start.c.obj
[77/95] Building C object esp-idf/log/CMakeFiles/__idf_log.dir/log_noos.c.obj
[78/95] Building C object esp-idf/log/CMakeFiles/__idf_log.dir/log.c.obj
[79/95] Building C object esp-idf/log/CMakeFiles/__idf_log.dir/log_buffers.c.obj
[80/95] Linking C static library esp-idf/log/liblog.a
[81/95] Building C object esp-idf/esp_rom/CMakeFiles/__idf_esp_rom.dir/patches/esp_rom_spiflash.c.obj
[82/95] Linking C static library esp-idf/esp_rom/libesp_rom.a
[83/95] Linking C static library esp-idf/esp_common/libesp_common.a
[84/95] Linking C static library esp-idf/xtensa/libxtensa.a
[85/95] Linking C static library esp-idf/esp_hw_support/libesp_hw_support.a
[86/95] Linking C static library esp-idf/esp_system/libesp_system.a
[87/95] Linking C static library esp-idf/efuse/libefuse.a
[88/95] Linking C static library esp-idf/bootloader_support/libbootloader_support.a
[89/95] Linking C static library esp-idf/hal/libhal.a
[90/95] Linking C static library esp-idf/micro-ecc/libmicro-ecc.a
[91/95] Linking C static library esp-idf/soc/libsoc.a
[92/95] Linking C static library esp-idf/main/libmain.a
[93/95] Linking C executable bootloader.elf
[94/95] Generating binary image from built executable
esptool.py v3.3-dev
Creating esp32 image...
Merged 1 ELF section
Successfully created esp32 image.
Generated /esp-hosted/esp/esp_driver/network_adapter/build/bootloader/bootloader.bin
[95/95] cd /esp-hosted/esp/esp_driver/network_adapter/build/bootloader/esp-idf/esptool_py && /opt/esp/python_env/idf5.0_py3.8_env/bin/python /opt/esp/idf/components/partition_table/check_sizes.py --offset 0x8000 bootloader 0x1000 /esp-hosted/esp/esp_driver/network_adapter/build/bootloader/bootloader.bin
Bootloader binary size 0x6350 bytes. 0xcb0 bytes (11%) free.
ninja: build stopped: subcommand failed.
ninja failed with exit code 1

```
# fixing
include header  "soc/gpio_reg.h" for ```GPIO_OUT_W1TC_REG```  and  ``` GPIO_OUT1_W1TS_REG```
