### PR TITLE
Careful cleanup in spi_exit

### DIFF
--- a/esp_hosted_fg/host/linux/host_driver/esp32/esp_serial.c
+++ b/esp_hosted_fg/host/linux/host_driver/esp32/esp_serial.c
@@ -44,7 +44,7 @@ static struct esp_serial_devs {
 	esp_rb_t rb;
 	void *priv;
 	struct mutex lock;
-} devs[ESP_SERIAL_MINOR_MAX];
+} devs[ESP_SERIAL_MINOR_MAX] = {{ 0 }};
 
 static uint8_t serial_init_done;
 
@@ -260,6 +260,10 @@ void esp_serial_cleanup(void)
 	int i = 0;
 
 	for (i = 0; i < ESP_SERIAL_MINOR_MAX; i++) {
+		if (!devs[i].cdev.ops) {
+			printk(KERN_INFO "%s: cdev[%d] is not initialized\n", __func__, i);
+			continue;
+		}
 		cdev_del(&devs[i].cdev);
 		esp_rb_cleanup(&devs[i].rb);
 		mutex_destroy(&devs[i].lock);

--- a/esp_hosted_fg/host/linux/host_driver/esp32/main.c
+++ b/esp_hosted_fg/host/linux/host_driver/esp32/main.c
@@ -671,13 +671,13 @@ error_exit:
 
 static void esp_remove_network_interfaces(struct esp_adapter *adapter)
 {
-	if (adapter->priv[0]->ndev) {
+	if (adapter->priv[0] && adapter->priv[0]->ndev) {
 		netif_stop_queue(adapter->priv[0]->ndev);
 		unregister_netdev(adapter->priv[0]->ndev);
 		free_netdev(adapter->priv[0]->ndev);
 	}
 
-	if (adapter->priv[1]->ndev) {
+	if (adapter->priv[1] && adapter->priv[1]->ndev) {
 		netif_stop_queue(adapter->priv[1]->ndev);
 		unregister_netdev(adapter->priv[1]->ndev);
 		free_netdev(adapter->priv[1]->ndev);


### PR DESCRIPTION
Avoid deleting a cdev that was never added; or unregistering a netdev that was never registered. this fixes issue #179: "When inserting linux spi driver as a module, failure to connect to a spi controller results in a crash"