### PR TITLE
FG: Use explicit macro for MCU ports.

### DIFF
--- a/esp_hosted_fg/host/control_lib/src/ctrl_core.c
+++ b/esp_hosted_fg/host/control_lib/src/ctrl_core.c
@@ -11,7 +11,7 @@
 #include <unistd.h>
 
 
-#ifdef STM32F469xx
+#ifdef MCU_SYS
 #include "common.h"
 #define command_log(...)             printf(__VA_ARGS__); printf("\r");
 #else
@@ -20,7 +20,7 @@
 #define min(X, Y)                    (((X) < (Y)) ? (X) : (Y))
 #endif
 
-#ifndef STM32F469xx
+#ifndef MCU_SYS
 #define MAX_INTERFACE_LEN            IFNAMSIZ
 #define MAC_SIZE_BYTES               6
 #define MIN_MAC_STR_LEN              17
@@ -160,7 +160,7 @@ static inline int is_ctrl_lib_state(int state)
 }
 
 
-#ifndef STM32F469xx
+#ifndef MCU_SYS
  /* Function converts mac string to byte stream */
 static int convert_mac_to_bytes(uint8_t *out, size_t out_size, char *s)
 {
@@ -1534,7 +1534,7 @@ int deinit_hosted_control_lib_internal(void)
 int init_hosted_control_lib_internal(void)
 {
 	int ret = SUCCESS;
-#ifndef STM32F469xx
+#ifndef MCU_SYS
 	if(getuid()) {
 		printf("Please re-run program with superuser access\n");
 		return FAILURE;
@@ -1582,7 +1582,7 @@ free_bufs:
 
 
 
-#ifndef STM32F469xx
+#ifndef MCU_SYS
 
  /* Function ups in given interface */
 int interface_up(int sockfd, char* iface)

--- a/esp_hosted_fg/host/stm32/port/include/platform_wrapper.h
+++ b/esp_hosted_fg/host/stm32/port/include/platform_wrapper.h
@@ -9,6 +9,8 @@
 #include <unistd.h>
 #include <sys/types.h>
 
+#define MCU_SYS                                1
+
 #define TIMEOUT_PSERIAL_RESP                   30
 
 #define CTRL__TIMER_ONESHOT                    0

--- a/esp_hosted_fg/host/virtual_serial_if/src/serial_if.c
+++ b/esp_hosted_fg/host/virtual_serial_if/src/serial_if.c
@@ -14,7 +14,7 @@
 #define PROTO_PSER_TLV_T_EPNAME           0x01
 #define PROTO_PSER_TLV_T_DATA             0x02
 
-#ifdef STM32F469xx
+#ifdef MCU_SYS
 #define command_log(format, ...)          printf(format "\r", ##__VA_ARGS__);
 #else
 #define command_log(...)                  printf("%s:%u ",__func__,__LINE__); \


### PR DESCRIPTION
The current FG ctrl_api relies "STM32F469xx" macro to be defined for MCU hosts without unistd and socket APIs. As this macro is implicitly defined by STM projects when the target MCU is the same as the discovery board (STM32F469I), this could be a issue if a different MCU platform is used.
This patch make this selection clear by using a seperate macro defined in "platform_wrapper.h", which can be defined by the user as required.

Signed-off-by: Yilin Sun <imi415@imi.moe>