### PR TITLE
Return err code when a Ringbuffer is full or inaccessible

### DIFF
--- a/esp_hosted_fg/host/linux/host_driver/esp32/esp_rb.c
+++ b/esp_hosted_fg/host/linux/host_driver/esp32/esp_rb.c
@@ -116,7 +116,7 @@ int esp_rb_write_by_kernel(esp_rb_t *rb, const char *buf, size_t sz)
 	if (get_free_space(rb) <= 0) {
 		up(&rb->sem);
 		printk(KERN_ERR "%s, %d, Ringbuffer full or inaccessible\n", __func__, __LINE__);
-		return 0;
+		return -EFAULT;
 	}
 
 	sz = min(sz, (size_t)get_free_space(rb));


### PR DESCRIPTION
esp_rb_write_by_kernel() returns the number of bytes written; and it is called repeatedly until the entire length of the packet has been transferred. In the case of a full/inaccessible ringbuffer, it was returning zero, causing the caller to invoke the function in a tight loop. Fixed to return -EFAULT.