### PR TITLE
spi_slave_api.c: Allow to use GPIO 32 and 33 for interface signals.

### DIFF
--- a/esp_hosted_fg/esp/esp_driver/network_adapter/main/spi_slave_api.c
+++ b/esp_hosted_fg/esp/esp_driver/network_adapter/main/spi_slave_api.c
@@ -143,8 +143,8 @@ static const char TAG[] = "SPI_DRIVER";
 
 #endif
 
-#define GPIO_MASK_DATA_READY (1 << CONFIG_ESP_SPI_GPIO_DATA_READY)
-#define GPIO_MASK_HANDSHAKE (1 << CONFIG_ESP_SPI_GPIO_HANDSHAKE)
+#define GPIO_MASK_DATA_READY (1ull << CONFIG_ESP_SPI_GPIO_DATA_READY)
+#define GPIO_MASK_HANDSHAKE (1ull << CONFIG_ESP_SPI_GPIO_HANDSHAKE)
 
 
 /* SPI internal configs */
@@ -217,22 +217,22 @@ static inline void spi_trans_free(spi_slave_transaction_t *trans)
 
 static inline void set_handshake_gpio(void)
 {
-	WRITE_PERI_REG(GPIO_OUT_W1TS_REG, GPIO_MASK_HANDSHAKE);
+	gpio_set_level(CONFIG_ESP_SPI_GPIO_HANDSHAKE, 1);
 }
 
 static inline void reset_handshake_gpio(void)
 {
-	WRITE_PERI_REG(GPIO_OUT_W1TC_REG, GPIO_MASK_HANDSHAKE);
+	gpio_set_level(CONFIG_ESP_SPI_GPIO_HANDSHAKE, 0);
 }
 
 static inline void set_dataready_gpio(void)
 {
-	WRITE_PERI_REG(GPIO_OUT_W1TS_REG, GPIO_MASK_DATA_READY);
+	gpio_set_level(CONFIG_ESP_SPI_GPIO_DATA_READY, 1);
 }
 
 static inline void reset_dataready_gpio(void)
 {
-	WRITE_PERI_REG(GPIO_OUT_W1TC_REG, GPIO_MASK_DATA_READY);
+	gpio_set_level(CONFIG_ESP_SPI_GPIO_DATA_READY, 0);
 }
 
 interface_context_t *interface_insert_driver(int (*event_handler)(uint8_t val))


### PR DESCRIPTION
Using consistently the IDF API instead of direct port access. There is a small performace drop compared to direct port access for setting the pin, but that can be accepted in favoer of consistence.

GPIO33 for instance is used by Adafruit and NINA modules for the handshake signal, and these modules cannot be rewired.