### PR TITLE
esp_hosted_ng: host: fix build failure when CONFIG_PM is not defined

### DIFF
--- a/esp_hosted_ng/host/esp_cfg80211.c
+++ b/esp_hosted_ng/host/esp_cfg80211.c
@@ -638,7 +638,9 @@ int esp_cfg80211_register(struct esp_adapter *adapter)
 	wiphy->max_scan_ie_len = 1000;
 	wiphy->max_sched_scan_ssids = 10;
 	wiphy->signal_type = CFG80211_SIGNAL_TYPE_MBM;
+#ifdef CONFIG_PM
 	wiphy->wowlan = &esp_wowlan_support;
+#endif
 
 	/* Advertise SAE support */
 	wiphy->features |= NL80211_FEATURE_SAE;


### PR DESCRIPTION
wiphy->wowlan is not defined when CONFIG_PM is not enabled so let's guard the assignment to wiphy->wowlan according to option CONFIG_PM.