### PR TITLE
Fix esp_hosted_ng build failure after cosmetic

### DIFF
--- a/esp_hosted_ng/host/include/utils.h
+++ b/esp_hosted_ng/host/include/utils.h
@@ -7,7 +7,7 @@
 #define pr_fmt(fmt) "%s:%s: " fmt, KBUILD_MODNAME, __func__
 
 #ifndef NUMBER_1M
-#define define NUMBER_1M 1000000
+#define NUMBER_1M 1000000
 #endif
 
 #ifndef MAC2STR


### PR DESCRIPTION
Commit 42fbb2e60205321e9f810209ad35cb7594494542 introduced a wrong double "define" on macro definition resulting in build failure, so let's remove it.