### PR TITLE
esp_hosted_ng: fix build failure on Linux 6.9.0

### DIFF
--- a/esp_hosted_ng/host/include/esp_kernel_port.h
+++ b/esp_hosted_ng/host/include/esp_kernel_port.h
@@ -230,4 +230,9 @@ static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
 }
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
+#define spi_master			spi_controller
+#define spi_master_put(_ctlr)		spi_controller_put(_ctlr)
+#endif
+
 #endif


### PR DESCRIPTION
With Linux commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=620d269f29a569ba37419cc03cf1da2d55f6252a spi_master compatibility has gone, so let's redefine missing needed macros spi_master and spi_master_put() locally if Linux version is >= 6.9.0.