### PR TITLE
Change scan type from passive to active

### DIFF
--- a/esp_hosted_ng/esp/esp_driver/network_adapter/main/cmd.c
+++ b/esp_hosted_ng/esp/esp_driver/network_adapter/main/cmd.c
@@ -1201,7 +1201,7 @@ int process_auth_request(uint8_t if_type, uint8_t *payload, uint16_t payload_len
 			assert(params.bssid);
 
 			memcpy(params.bssid, cmd_auth->bssid, sizeof(cmd_auth->bssid));
-			params.scan_type = 1;
+			params.scan_type = WIFI_SCAN_TYPE_ACTIVE;
 		}
 
 		if (cmd_auth->channel) {


### PR DESCRIPTION
I ran into a situation where I was unable to connect to a particular AP (Unifi U6 Lite) and tracked it down to the scan type being passive vs an active one.

Perhaps we could tune the beacon frequency on this AP, but I figured that I would bring up the matter with you guys.  :-)

Even if this is not the desired behavior and you wish to keep the passive scan in place, the enum should be used instead of '1'.