### PR TITLE
esp_hosted_ng: Fix Bluetooth build failure on Linux 6.8.11+

### DIFF
--- a/esp_hosted_ng/host/esp_bt.c
+++ b/esp_hosted_ng/host/esp_bt.c
@@ -240,7 +240,9 @@ int esp_init_bt(struct esp_adapter *adapter)
 	hdev->set_bdaddr = esp_bt_set_bdaddr;
 #endif
 
+#ifdef HCI_PRIMARY
 	hdev->dev_type = HCI_PRIMARY;
+#endif
 
 	SET_HCIDEV_DEV(hdev, adapter->dev);
 


### PR DESCRIPTION
After Linux commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=84a4bb6548a29326564f0e659fb8064503ecc1c7 BT_HS has been removed and consequently AMP controllers can't be created, so at this point only HCI_PRIMARY has been left as unique controller type to be created and this became implicit with no need to define if the controller if HCI_PRIMARY or HCI_AMP. So let's assign HCI_PRIMARY up to Linux 6.8.11 only preventing build failure.