### PR TITLE
Add WiFi packet flow control

### DIFF
--- a/esp_hosted_fg/esp/esp_driver/network_adapter/main/interface.h
+++ b/esp_hosted_fg/esp/esp_driver/network_adapter/main/interface.h
@@ -26,6 +26,8 @@
 	#error "SDIO is not supported for this chipset"
 #endif
 
+#include "sdio_slave_api.h"
+
 #endif
 
 typedef enum {
@@ -78,7 +80,11 @@ typedef struct {
 typedef struct {
 	interface_handle_t * (*init)(void);
 	int32_t (*write)(interface_handle_t *handle, interface_buffer_handle_t *buf_handle);
+#ifdef CONFIG_ESP_SDIO_HOST_INTERFACE
+	int (*read)(interface_handle_t *handle, interface_buffer_handle_t *buf_handle, TickType_t wait);
+#else
 	int (*read)(interface_handle_t *handle, interface_buffer_handle_t *buf_handle);
+#endif
 	esp_err_t (*reset)(interface_handle_t *handle);
 	void (*deinit)(interface_handle_t *handle);
 } if_ops_t;

--- a/esp_hosted_fg/esp/esp_driver/network_adapter/main/sdio_slave_api.c
+++ b/esp_hosted_fg/esp/esp_driver/network_adapter/main/sdio_slave_api.c
@@ -30,7 +30,7 @@
 
 #define SDIO_SLAVE_QUEUE_SIZE   20
 #define BUFFER_SIZE     	1536 /* 512*3 */
-#define BUFFER_NUM      	10
+
 static uint8_t sdio_slave_rx_buffer[BUFFER_NUM][BUFFER_SIZE];
 
 #define SDIO_MEMPOOL_NUM_BLOCKS     40
@@ -43,7 +43,7 @@ static const char TAG[] = "SDIO_SLAVE";
 
 static interface_handle_t * sdio_init(void);
 static int32_t sdio_write(interface_handle_t *handle, interface_buffer_handle_t *buf_handle);
-static int sdio_read(interface_handle_t *if_handle, interface_buffer_handle_t *buf_handle);
+static int sdio_read(interface_handle_t *if_handle, interface_buffer_handle_t *buf_handle, TickType_t wait);
 static esp_err_t sdio_reset(interface_handle_t *handle);
 static void sdio_deinit(interface_handle_t *handle);
 
@@ -339,7 +339,7 @@ static int32_t sdio_write(interface_handle_t *handle, interface_buffer_handle_t 
 	return buf_handle->payload_len;
 }
 
-static int sdio_read(interface_handle_t *if_handle, interface_buffer_handle_t *buf_handle)
+static int sdio_read(interface_handle_t *if_handle, interface_buffer_handle_t *buf_handle, TickType_t wait)
 {
 	esp_err_t ret = ESP_OK;
 	struct esp_payload_header *header = NULL;
@@ -359,7 +359,7 @@ static int sdio_read(interface_handle_t *if_handle, interface_buffer_handle_t *b
 		return ESP_FAIL;
 
 	ret = sdio_slave_recv(&(buf_handle->sdio_buf_handle), &(buf_handle->payload),
-			&(sdio_read_len), portMAX_DELAY);
+			&(sdio_read_len), wait);
 	if (ret) {
 		ESP_LOGD(TAG, "sdio_slave_recv returned failure");
 		return ESP_FAIL;

--- a/esp_hosted_fg/esp/esp_driver/network_adapter/main/sdio_slave_api.h
+++ b/esp_hosted_fg/esp/esp_driver/network_adapter/main/sdio_slave_api.h
@@ -22,4 +22,6 @@
     #error "SDIO is not supported for ESP32S2. Please use SPI"
 #endif
 
+#define BUFFER_NUM      	10
+
 #endif


### PR DESCRIPTION
I added flow control for wifi packets. This will greatly reduce the packet loss rate (tested by sending udp via iperf). But it only supports the sdio interface because I think the current spi communication implementation is not compatible with the flow control mechanism. At the same time, when I checked the spi communication, I found that there are still some problems:
The number of SPI memory pools is only SPI_MEMPOOL_NUM_BLOCKS, but the number of spi_tx_queue and spi_rx_queue queues is three times that. I think in extreme cases, when the memory pool is exhausted and all the memory is in spi_rx_queue/spi_tx_queue, the next spi transmission will fail to apply for memory, triggering assert
