### PR TITLE
fix: build error:  slave_control.c

### DIFF
--- a/esp_hosted_fg/esp/esp_driver/network_adapter/main/slave_control.c
+++ b/esp_hosted_fg/esp/esp_driver/network_adapter/main/slave_control.c
@@ -2599,7 +2599,9 @@ static esp_err_t ctrl_ntfy_StationDisconnectFromESPSoftAP(CtrlMsg *ntfy,
 	ntfy_payload->resp = FAILURE;
 	ntfy_payload->aid = evt->aid;
 	ntfy_payload->is_mesh_child = evt->is_mesh_child;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 1)
 	ntfy_payload->reason = evt->reason;
+#endif
 
 	snprintf(mac_str, BSSID_LENGTH, MACSTR, MAC2STR(evt->mac));
 	ntfy_payload->mac.len = strnlen(mac_str, BSSID_LENGTH);


### PR DESCRIPTION
fixes #486

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
build error in slave_control.c : structure member not found
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
