### PR TITLE
fix(esp_hosted_ng): actively process RX packets

### DIFF
--- a/esp_hosted_ng/host/main.c
+++ b/esp_hosted_ng/host/main.c
@@ -952,12 +952,8 @@ static int esp_get_packets(struct esp_adapter *adapter)
 	if (!adapter || !adapter->if_ops || !adapter->if_ops->read)
 		return -EINVAL;
 
-	skb = adapter->if_ops->read(adapter);
-
-	if (!skb)
-		return -EFAULT;
-
-	process_rx_packet(adapter, skb);
+	while ((skb = adapter->if_ops->read(adapter)))
+		process_rx_packet(adapter, skb);
 
 	return 0;
 }


### PR DESCRIPTION
## Description

The RX packet handling works by queuing `esp_if_rx_work` to `if_rx_workqueue` which will read just one packet from the highest priority RX queue with a packet available, and then push it to the Linux network stack. The process will repeat after new Handshake/Data Ready interrupt is handled.

When trying to queue the processing of a new packet, if some work is not finished, for example: when the CPU and network (specifically RX) load are high, the new packet will be silently dropped. This leads to a build up in the RX queue. As just one packet will be handled on the next call, leaving unhandled packets laying in the queue.

The proposed solution, reads and process all available packets in the RX queue and pushes them to the Linux network stack before finishing.


## Related

Fixes #600  - Network performance drops with traffic volume

## Testing
This test is system dependent, as it requires being able to increase the network and CPU pressure on a system. 

Set up an iperf server in a different computer in the same network with
```
iperf3 -s
```

And from the Linux box using the esp32 hosted-NG driver:

As a diagnostic, run the following
```
ping <ROUTER IP>
```
And to saturate the ESP32 link:
```
iperf3 -c <SERVER IP> -k 1G -P 10 -R
```

After some time, it can be observed that ping latencies rise significantly.
After stopping the `iperf3` client, latencies won't go back to normal.

**After this fix:**
Stopping the `iperf3` client causes the latencies to quickly normalize.
