### PR TITLE
fix(esp_hosted_ng): Remove specific compilation SDIO left-overs

### DIFF
--- a/esp_hosted_ng/docs/setup.md
+++ b/esp_hosted_ng/docs/setup.md
@@ -262,14 +262,6 @@ directory
     * Please reboot Raspberry-Pi after changing this file.
 * Setting up the environment and getting started
     * Host environment setup  
-        * As ESP32 & ESP32C6, both support SDIO, Let host know which slave chipset is being used by changing `ESP_SLAVE_CHIPSET` in `esp_hosted_ng/host/rpi_init.sh` as:
-            ```sh
-            ESP_SLAVE_CHIPSET="esp32"
-            ```
-            or
-            ```sh
-            ESP_SLAVE_CHIPSET="esp32c6"
-            ```
         * Execute following commands in root directory of cloned ESP-Hosted repository on Raspberry-Pi
             ```sh
             $ cd esp_hosted/esp_hosted_ng/host/

--- a/esp_hosted_ng/host/rpi_init.sh
+++ b/esp_hosted_ng/host/rpi_init.sh
@@ -42,9 +42,6 @@ wlan_init()
         fi
     fi
 
-    if [ "$ESP_SLAVE" != "" ] ; then
-        CUSTOM_OPTS=${CUSTOM_OPTS}" ESP_SLAVE=\"$ESP_SLAVE"\"
-    fi
     if [ "$CUSTOM_OPTS" != "" ] ; then
         echo "Adding $CUSTOM_OPTS"
     fi


### PR DESCRIPTION
With commit b544b01e201bdef20c680a6902c1495e46dde1ff something has been left behind:
* Documentation of ESP_SLAVE_CHIPSET
* ESP_SLAVE variable both don't exist anymore. So drop comments and script usage

