### PR TITLE
fix(ng/host/spi): fix OOB reads when tx skb len < SPI_BUF_SIZE

### DIFF
--- a/esp_hosted_ng/host/esp_bt.c
+++ b/esp_hosted_ng/host/esp_bt.c
@@ -113,7 +113,7 @@ static ESP_BT_SEND_FRAME_PROTOTYPE()
 
 		/* Populate new SKB */
 		skb_copy_from_linear_data(skb, pos, skb->len);
-		skb_put(new_skb, skb->len);
+		skb_put(new_skb, skb->len + pad_len);
 
 		/* Replace old SKB */
 		dev_kfree_skb_any(skb);

--- a/esp_hosted_ng/host/spi/esp_spi.c
+++ b/esp_hosted_ng/host/spi/esp_spi.c
@@ -41,8 +41,6 @@ static struct esp_if_ops if_ops = {
 	.write		= write_packet,
 };
 
-static DEFINE_MUTEX(spi_lock);
-
 static void open_data_path(void)
 {
 	atomic_set(&tx_pending, 0);
@@ -278,93 +276,108 @@ static void esp_spi_work(struct work_struct *work)
 	int ret = 0;
 	volatile int trans_ready, rx_pending;
 
-	mutex_lock(&spi_lock);
-
 	trans_ready = gpio_get_value(HANDSHAKE_PIN);
 	rx_pending = gpio_get_value(SPI_DATA_READY_PIN);
 
-	if (trans_ready) {
-		if (data_path) {
-			tx_skb = skb_dequeue(&spi_context.tx_q[PRIO_Q_HIGH]);
-			if (!tx_skb)
-				tx_skb = skb_dequeue(&spi_context.tx_q[PRIO_Q_MID]);
-			if (!tx_skb)
-				tx_skb = skb_dequeue(&spi_context.tx_q[PRIO_Q_LOW]);
-			if (tx_skb) {
-				if (atomic_read(&tx_pending))
-					atomic_dec(&tx_pending);
+	if (!trans_ready) {
+		return;
+	}
 
-				/* resume network tx queue if bearable load */
-				cb = (struct esp_skb_cb *)tx_skb->cb;
-				if (cb && cb->priv && atomic_read(&tx_pending) < TX_RESUME_THRESHOLD) {
-					esp_tx_resume(cb->priv);
+	if (data_path) {
+		tx_skb = skb_dequeue(&spi_context.tx_q[PRIO_Q_HIGH]);
+		if (!tx_skb)
+			tx_skb = skb_dequeue(&spi_context.tx_q[PRIO_Q_MID]);
+		if (!tx_skb)
+			tx_skb = skb_dequeue(&spi_context.tx_q[PRIO_Q_LOW]);
+		if (tx_skb) {
+			if (atomic_read(&tx_pending))
+				atomic_dec(&tx_pending);
+
+			/* resume network tx queue if bearable load */
+			cb = (struct esp_skb_cb *)tx_skb->cb;
+			if (cb && cb->priv && atomic_read(&tx_pending) < TX_RESUME_THRESHOLD) {
+				esp_tx_resume(cb->priv);
 #if TEST_RAW_TP
-					if (raw_tp_mode != 0) {
-						esp_raw_tp_queue_resume();
-					}
-#endif
+				if (raw_tp_mode != 0) {
+					esp_raw_tp_queue_resume();
 				}
-			}
-		}
-
-		if (rx_pending || tx_skb) {
-			memset(&trans, 0, sizeof(trans));
-			trans.speed_hz = spi_context.spi_clk_mhz * NUMBER_1M;
-
-			/* Setup and execute SPI transaction
-			 *	Tx_buf: Check if tx_q has valid buffer for transmission,
-			 *		else keep it blank
-			 *
-			 *	Rx_buf: Allocate memory for incoming data. This will be freed
-			 *		immediately if received buffer is invalid.
-			 *		If it is a valid buffer, upper layer will free it.
-			 * */
-
-			/* Configure TX buffer if available */
-
-			if (tx_skb) {
-				trans.tx_buf = tx_skb->data;
-				esp_hex_dump_verbose("tx: ", trans.tx_buf, 32);
-			} else {
-				tx_skb = esp_alloc_skb(SPI_BUF_SIZE);
-				trans.tx_buf = skb_put(tx_skb, SPI_BUF_SIZE);
-				memset((void *)trans.tx_buf, 0, SPI_BUF_SIZE);
-			}
-
-			/* Configure RX buffer */
-			rx_skb = esp_alloc_skb(SPI_BUF_SIZE);
-			rx_buf = skb_put(rx_skb, SPI_BUF_SIZE);
-
-			memset(rx_buf, 0, SPI_BUF_SIZE);
-
-			trans.rx_buf = rx_buf;
-			trans.len = SPI_BUF_SIZE;
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
-			if (hardware_type == ESP_FIRMWARE_CHIP_ESP32) {
-				trans.cs_change = 1;
-			}
 #endif
-
-			ret = spi_sync_transfer(spi_context.esp_spi_dev, &trans, 1);
-			if (ret) {
-				esp_err("SPI Transaction failed: %d", ret);
-				dev_kfree_skb(rx_skb);
-				dev_kfree_skb(tx_skb);
-			} else {
-
-				/* Free rx_skb if received data is not valid */
-				if (process_rx_buf(rx_skb)) {
-					dev_kfree_skb(rx_skb);
-				}
-
-				if (tx_skb)
-					dev_kfree_skb(tx_skb);
 			}
 		}
 	}
 
-	mutex_unlock(&spi_lock);
+	if (!rx_pending && !tx_skb) {
+		return;
+	}
+
+	memset(&trans, 0, sizeof(trans));
+	trans.speed_hz = spi_context.spi_clk_mhz * NUMBER_1M;
+
+	/* Setup and execute SPI transaction
+	 *	Tx_buf: Check if tx_q has valid buffer for transmission,
+	 *		else keep it blank
+	 *
+	 *	Rx_buf: Allocate memory for incoming data. This will be freed
+	 *		immediately if received buffer is invalid.
+	 *		If it is a valid buffer, upper layer will free it.
+	 * */
+
+	/* Configure TX buffer if available */
+
+	if (tx_skb) {
+		if (tx_skb->len < SPI_BUF_SIZE) {
+			struct sk_buff *tx_skb_new = esp_alloc_skb(SPI_BUF_SIZE);
+			if (!tx_skb_new) {
+				dev_kfree_skb(tx_skb);
+				return;
+			}
+
+			skb_put(tx_skb_new, SPI_BUF_SIZE);
+			skb_copy_from_linear_data(tx_skb, tx_skb_new->data, tx_skb->len);
+			dev_kfree_skb(tx_skb);
+			tx_skb = tx_skb_new;
+		}
+		trans.tx_buf = tx_skb->data;
+		esp_hex_dump_verbose("tx: ", trans.tx_buf, 32);
+	} else {
+		tx_skb = esp_alloc_skb(SPI_BUF_SIZE);
+		if (!tx_skb) {
+			return;
+		}
+		trans.tx_buf = skb_put(tx_skb, SPI_BUF_SIZE);
+		memset((void *)trans.tx_buf, 0, SPI_BUF_SIZE);
+	}
+
+	/* Configure RX buffer */
+	rx_skb = esp_alloc_skb(SPI_BUF_SIZE);
+	rx_buf = skb_put(rx_skb, SPI_BUF_SIZE);
+
+	memset(rx_buf, 0, SPI_BUF_SIZE);
+
+	trans.rx_buf = rx_buf;
+	trans.len = SPI_BUF_SIZE;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
+	if (hardware_type == ESP_FIRMWARE_CHIP_ESP32) {
+		trans.cs_change = 1;
+	}
+#endif
+
+	ret = spi_sync_transfer(spi_context.esp_spi_dev, &trans, 1);
+	if (ret) {
+		esp_err("SPI Transaction failed: %d", ret);
+		dev_kfree_skb(rx_skb);
+		dev_kfree_skb(tx_skb);
+	} else {
+
+		/* Free rx_skb if received data is not valid */
+		if (process_rx_buf(rx_skb)) {
+			dev_kfree_skb(rx_skb);
+		}
+
+		if (tx_skb)
+			dev_kfree_skb(tx_skb);
+	}
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0))
@@ -530,7 +543,7 @@ static int spi_init(void)
 	uint8_t prio_q_idx = 0;
 	struct esp_adapter *adapter;
 
-	spi_context.spi_workqueue = create_workqueue("ESP_SPI_WORK_QUEUE");
+	spi_context.spi_workqueue = alloc_ordered_workqueue("ESP_SPI_WORK_QUEUE", 0);
 
 	if (!spi_context.spi_workqueue) {
 		esp_err("spi workqueue failed to create\n");


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

The SPI framing protocol assumes `SPI_BUF_SIZE` transfer sizes, but the tx skb size is not extended to cover that. This results in out-of-bounds reads, sending random kernel memory down the bus.

I fixed this by re-allocating the tx skb whenever its size is smaller than `SPI_BUF_SIZE`. This is done before the SPI transfer. A more efficient approach would be to do this in `process_tx_packet()`, where the skb is usually re-allocated anyway to meet alignment requirements. But since that happens in the transport-independent part of the driver it would require some more refactoring.

The `esp_spi_work()` function, where I added the new logic, was already nesting a lot so I took the liberty to refactor it a bit, including throwing away the mutex and instead enforcing serial execution with `alloc_ordered_workqueue()`. If hope that's ok.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->


## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

I tested this by running a BLE speed test for about 10 mins (`l2cat`, part of [bluer](https://github.com/bluez/bluer)) on the following setup:
 - ESP32-C6 as controller
 - Raspberry Pi 3b with `6.12.47+rpt-rpi-v8`
 - my other Linux PC as BLE peer

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
