### PR TITLE
fix(esp_hosted_ng): Fix build for kernel 7.1

### DIFF
--- a/esp_hosted_ng/host/esp_cfg80211.c
+++ b/esp_hosted_ng/host/esp_cfg80211.c
@@ -533,22 +533,38 @@ static int esp_cfg80211_set_default_key(struct wiphy *wiphy,
 }
 
 static int esp_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+					     struct wireless_dev *wdev, INT_LINK_ID u8 key_index)
+#else
 					     struct net_device *ndev, INT_LINK_ID u8 key_index)
+#endif
 {
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+static int esp_cfg80211_del_key(struct wiphy *wiphy, struct wireless_dev *wdev,
+#else
 static int esp_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+#endif
 				INT_LINK_ID u8 key_index, bool pairwise,
 				const u8 *mac_addr)
 {
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+static int esp_cfg80211_add_key(struct wiphy *wiphy, struct wireless_dev *wdev,
+				INT_LINK_ID u8 key_index, bool pairwise,
+				const u8 *mac_addr, struct key_params *params)
+{
+	struct net_device *dev = wdev->netdev;
+#else
 static int esp_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
 				INT_LINK_ID u8 key_index, bool pairwise,
 				const u8 *mac_addr, struct key_params *params)
 {
+#endif
 	struct esp_wifi_device *priv = NULL;
 
 	if (!wiphy || !dev || !params) {
@@ -564,7 +580,11 @@ static int esp_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
 	esp_dbg("\n");
 
 	if (params->key_len == 0) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+		return esp_cfg80211_del_key(wiphy, wdev, ZERO_LINK_ID key_index, pairwise, mac_addr);
+#else
 		return esp_cfg80211_del_key(wiphy, dev, ZERO_LINK_ID key_index, pairwise, mac_addr);
+#endif
 	}
 	return cmd_add_key(priv, key_index, pairwise, mac_addr, params);
 }
@@ -783,9 +803,16 @@ static int esp_cfg80211_set_tx_power(struct wiphy *wiphy,
 	return cmd_set_tx_power(priv, priv->tx_pwr);
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+static int esp_cfg80211_get_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+				    const u8 *mac, struct station_info *sinfo)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int esp_cfg80211_get_station(struct wiphy *wiphy, struct net_device *ndev,
 				    const u8 *mac, struct station_info *sinfo)
 {
+#endif
 	struct esp_wifi_device *priv = NULL;
 
 	priv = netdev_priv(ndev);
@@ -1034,9 +1061,16 @@ static int esp_cfg80211_probe_client(struct wiphy *wiphy, struct net_device *dev
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+static int esp_cfg80211_del_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+					struct station_del_parameters *params)
+{
+	struct net_device *dev = wdev->netdev;
+#else
 static int esp_cfg80211_del_station(struct wiphy *wiphy, struct net_device *dev,
 					struct station_del_parameters *params)
 {
+#endif
 	struct esp_wifi_device *priv = NULL;
 
 	if (!wiphy || !dev) {
@@ -1055,10 +1089,18 @@ static int esp_cfg80211_del_station(struct wiphy *wiphy, struct net_device *dev,
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+static int esp_cfg80211_add_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+				    const u8 *mac,
+				    struct station_parameters *params)
+{
+	struct net_device *dev = wdev->netdev;
+#else
 static int esp_cfg80211_add_station(struct wiphy *wiphy, struct net_device *dev,
 				    const u8 *mac,
 				    struct station_parameters *params)
 {
+#endif
 	struct esp_wifi_device *priv = NULL;
 
 	if (!wiphy || !dev) {
@@ -1078,10 +1120,18 @@ static int esp_cfg80211_add_station(struct wiphy *wiphy, struct net_device *dev,
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+static int esp_cfg80211_change_station(struct wiphy *wiphy,
+				       struct wireless_dev *wdev, const u8 *mac,
+				       struct station_parameters *params)
+{
+	struct net_device *dev = wdev->netdev;
+#else
 static int esp_cfg80211_change_station(struct wiphy *wiphy,
 				       struct net_device *dev, const u8 *mac,
 				       struct station_parameters *params)
 {
+#endif
 	struct esp_wifi_device *priv = NULL;
 
 	if (!wiphy || !dev) {


### PR DESCRIPTION
With commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=033fe322f5852d5144a85978e880e01b1787fd0d many functions esp_cfg80211_*() have argument struct netdevice * subsituted with struct wireless_dev *. So let's add separate function headers and retrieve struct netdev * from struct wireless_dev * if Linux version >= 7.1.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
