### PR TITLE
Add log_level as module parameter

### DIFF
--- a/esp_hosted_ng/host/main.c
+++ b/esp_hosted_ng/host/main.c
@@ -51,6 +51,9 @@ MODULE_PARM_DESC(clockspeed, "Hosts clock speed in MHz");
 module_param(raw_tp_mode, uint, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(raw_tp_mode, "Mode chosen to test raw throughput");
 
+module_param(log_level, int, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+MODULE_PARM_DESC(log_level, "Log level: 1=ERR, 2=WARNING, 3=INFO, 4=DEBUG, 5=VERBOSE");
+
 module_param(ota_file, charp, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(ota_file, "Ota file to update ESP firmware");
 

--- a/esp_hosted_ng/host/spi/esp_spi.c
+++ b/esp_hosted_ng/host/spi/esp_spi.c
@@ -78,6 +78,7 @@ static void close_data_path(void)
 static irqreturn_t spi_data_ready_interrupt_handler(int irq, void *dev)
 {
 	/* ESP peripheral has queued buffer for transmission */
+	esp_verbose("Data ready interrupt: ESP has data\n");
 	if (spi_context.spi_workqueue)
 		queue_work(spi_context.spi_workqueue, &spi_context.spi_work);
 
@@ -87,6 +88,7 @@ static irqreturn_t spi_data_ready_interrupt_handler(int irq, void *dev)
 static irqreturn_t spi_interrupt_handler(int irq, void *dev)
 {
 	/* ESP peripheral is ready for next SPI transaction */
+	esp_verbose("Handshake: ESP ready for transfer\n");
 	if (spi_context.spi_workqueue)
 		queue_work(spi_context.spi_workqueue, &spi_context.spi_work);
 
@@ -349,7 +351,7 @@ static void esp_spi_work(struct work_struct *work)
 		}
 
 		trans.tx_buf = tx_skb->data;
-		esp_hex_dump_verbose("tx: ", trans.tx_buf, 32);
+		esp_hex_dump_verbose("TX: ", trans.tx_buf, 32);
 	} else {
 		tx_skb = esp_spi_alloc_skb(SPI_BUF_SIZE);
 		if (!tx_skb) {
@@ -385,6 +387,7 @@ static void esp_spi_work(struct work_struct *work)
 		dev_kfree_skb(rx_skb);
 		dev_kfree_skb(tx_skb);
 	} else {
+		esp_hex_dump_verbose("RX: ", rx_buf, 32);
 		/* Free rx_skb if received data is not valid */
 		if (process_rx_buf(rx_skb))
 			dev_kfree_skb(rx_skb);


### PR DESCRIPTION
This change makes the log_level a module parameter so that is can be easily changed without recompiling the module.
