### PR TITLE
Add verbose prints on interrupts, and print RX buffer

### DIFF
--- a/esp_hosted_ng/esp/esp_driver/network_adapter/main/spi_slave_api.c
+++ b/esp_hosted_ng/esp/esp_driver/network_adapter/main/spi_slave_api.c
@@ -128,7 +128,7 @@ uint8_t g_spi_mode = SPI_MODE_2;
 #define GPIO_CS                10
 #define DMA_CHAN               SPI_DMA_CH_AUTO
 
-#define SPI_CLK_MHZ            30
+#define SPI_CLK_MHZ            10
 
 #elif defined CONFIG_IDF_TARGET_ESP32C6
 

--- a/esp_hosted_ng/host/spi/esp_spi.c
+++ b/esp_hosted_ng/host/spi/esp_spi.c
@@ -78,6 +78,7 @@ static void close_data_path(void)
 static irqreturn_t spi_data_ready_interrupt_handler(int irq, void *dev)
 {
 	/* ESP peripheral has queued buffer for transmission */
+	esp_verbose("Data ready interrupt: ESP has data\n");
 	if (spi_context.spi_workqueue)
 		queue_work(spi_context.spi_workqueue, &spi_context.spi_work);
 
@@ -87,6 +88,7 @@ static irqreturn_t spi_data_ready_interrupt_handler(int irq, void *dev)
 static irqreturn_t spi_interrupt_handler(int irq, void *dev)
 {
 	/* ESP peripheral is ready for next SPI transaction */
+	esp_verbose("Handshake: ESP ready for transfer\n");
 	if (spi_context.spi_workqueue)
 		queue_work(spi_context.spi_workqueue, &spi_context.spi_work);
 
@@ -349,7 +351,7 @@ static void esp_spi_work(struct work_struct *work)
 		}
 
 		trans.tx_buf = tx_skb->data;
-		esp_hex_dump_verbose("tx: ", trans.tx_buf, 32);
+		esp_hex_dump_verbose("TX: ", trans.tx_buf, 32);
 	} else {
 		tx_skb = esp_spi_alloc_skb(SPI_BUF_SIZE);
 		if (!tx_skb) {
@@ -385,6 +387,7 @@ static void esp_spi_work(struct work_struct *work)
 		dev_kfree_skb(rx_skb);
 		dev_kfree_skb(tx_skb);
 	} else {
+		esp_hex_dump_verbose("RX: ", rx_buf, 32);
 		/* Free rx_skb if received data is not valid */
 		if (process_rx_buf(rx_skb))
 			dev_kfree_skb(rx_skb);


### PR DESCRIPTION
For SPI communication: Add verbose prints on data ready and handshake interrupt events. Also print the 32 first bytes the buffer received (previously only TX was printed)
